### PR TITLE
added missing name_ to ForceTorque class

### DIFF
--- a/pr2_hardware_interface/include/pr2_hardware_interface/hardware_interface.h
+++ b/pr2_hardware_interface/include/pr2_hardware_interface/hardware_interface.h
@@ -235,6 +235,7 @@ public:
 class ForceTorque
 {
 public:
+  std::string name_;
   ForceTorqueState state_;
   ForceTorqueCommand command_;
 };


### PR DESCRIPTION
This makes the ForceTorque class consistent with the other sensor/actuator classes. Fixes compile issue.
