### PR TITLE
missing target_link_libraries commands for required libraries are added.

### DIFF
--- a/pr2_controller_manager/CMakeLists.txt
+++ b/pr2_controller_manager/CMakeLists.txt
@@ -25,10 +25,11 @@ add_definitions(-O3)
 
 add_library(pr2_controller_manager src/controller_manager.cpp src/scheduler.cpp)
 
-target_link_libraries(pr2_controller_manager ${Boost_LIBRARIES})
+target_link_libraries(pr2_controller_manager ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_library(controller_test test/controllers/test_controller.cpp)
 pr2_enable_rpath(controller_test)
+target_link_libraries(controller_test ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_executable(test_controllers test/test.cpp)
 add_executable(test_robot test/robot.cpp)

--- a/pr2_mechanism_diagnostics/CMakeLists.txt
+++ b/pr2_mechanism_diagnostics/CMakeLists.txt
@@ -17,6 +17,7 @@ add_definitions(-O3)
 add_library(${PROJECT_NAME} 
   src/controller_diagnostics.cpp 
   src/joint_diagnostics.cpp)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 add_executable(pr2_mechanism_diagnostics_node src/pr2_mechanism_diagnostics.cpp)
 target_link_libraries(pr2_mechanism_diagnostics_node ${PROJECT_NAME} ${catkin_LIBRARIES})

--- a/pr2_mechanism_model/CMakeLists.txt
+++ b/pr2_mechanism_model/CMakeLists.txt
@@ -3,12 +3,13 @@ cmake_minimum_required(VERSION 2.8.3)
 project(pr2_mechanism_model)
 
 # Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED COMPONENTS roscpp pr2_hardware_interface urdf urdfdom kdl_parser pluginlib angles hardware_interface rostest rosunit)
+find_package(catkin REQUIRED COMPONENTS roscpp pr2_hardware_interface urdf kdl_parser pluginlib angles hardware_interface rostest rosunit)
 
 find_package(Eigen REQUIRED)
 find_package(orocos_kdl REQUIRED)
+find_package(urdfdom REQUIRED)
 include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS})
-include_directories(include ${catkin_INCLUDE_DIRS} ${orocos_kdl_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${orocos_kdl_INCLUDE_DIRS} ${urdfdom_INCLUDE_DIRS})
 
 catkin_package(
     DEPENDS tinyxml urdfdom

--- a/pr2_mechanism_model/CMakeLists.txt
+++ b/pr2_mechanism_model/CMakeLists.txt
@@ -6,8 +6,9 @@ project(pr2_mechanism_model)
 find_package(catkin REQUIRED COMPONENTS roscpp pr2_hardware_interface urdf urdfdom kdl_parser pluginlib angles hardware_interface rostest rosunit)
 
 find_package(Eigen REQUIRED)
+find_package(orocos_kdl REQUIRED)
 include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS})
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${orocos_kdl_INCLUDE_DIRS})
 
 catkin_package(
     DEPENDS tinyxml urdfdom
@@ -30,6 +31,7 @@ add_library( pr2_mechanism_model
   src/joint_calibration_simulator.cpp
 )
 pr2_enable_rpath(pr2_mechanism_model)
+target_link_libraries(pr2_mechanism_model ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
 
 catkin_add_gtest(test_chain test/test_chain.cpp)
 target_link_libraries(test_chain pr2_mechanism_model ${catkin_LIBRARIES})


### PR DESCRIPTION
They are needed for compiling on Mac OS X.
