### PR TITLE
Prevent ShortChainTest in  test_chain.cpp from failing.

### DIFF
--- a/pr2_controller_manager/CMakeLists.txt
+++ b/pr2_controller_manager/CMakeLists.txt
@@ -5,17 +5,19 @@ project(pr2_controller_manager)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS cmake_modules pr2_hardware_interface pr2_mechanism_model pr2_mechanism_diagnostics pr2_description pr2_controller_interface pr2_mechanism_msgs diagnostic_msgs sensor_msgs realtime_tools roscpp pluginlib rostest)
 
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system thread)
+find_package(TinyXML REQUIRED)
 
 include_directories(
    include 
    ${Boost_INCLUDE_DIRS} 
    ${catkin_INCLUDE_DIRS} 
-   ${EIGEN_INCLUDE_DIRS})
+   ${EIGEN_INCLUDE_DIRS}
+   ${TinyXML_INCLUDE_DIRS})
 
 catkin_package(
-    DEPENDS tinyxml
+    DEPENDS TinyXML
     CATKIN_DEPENDS pr2_hardware_interface pr2_mechanism_model pr2_mechanism_diagnostics pr2_description pr2_controller_interface pr2_mechanism_msgs diagnostic_msgs sensor_msgs realtime_tools roscpp pluginlib
     INCLUDE_DIRS include
     LIBRARIES pr2_controller_manager
@@ -24,19 +26,19 @@ catkin_package(
 add_definitions(-O3)
 
 add_library(pr2_controller_manager src/controller_manager.cpp src/scheduler.cpp)
-
-target_link_libraries(pr2_controller_manager ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(pr2_controller_manager ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${TinyXML_LIBRARIES})
 
 add_library(controller_test test/controllers/test_controller.cpp)
+add_dependencies(controller_test pr2_mechanism_msgs_generate_messages_cpp)
 pr2_enable_rpath(controller_test)
 target_link_libraries(controller_test ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_executable(test_controllers test/test.cpp)
-add_executable(test_robot test/robot.cpp)
-
-target_link_libraries(test_robot ${Boost_LIBRARIES} ${PROJECT_NAME} ${catkin_LIBRARIES})
-
+add_dependencies(test_controllers pr2_mechanism_msgs_generate_messages_cpp)
 target_link_libraries(test_controllers ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
+
+add_executable(test_robot test/robot.cpp)
+target_link_libraries(test_robot ${Boost_LIBRARIES} ${PROJECT_NAME} ${catkin_LIBRARIES})
 
 add_rostest(test/controller_test.launch)
 

--- a/pr2_controller_manager/package.xml
+++ b/pr2_controller_manager/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
+  <build_depend>tinyxml</build_depend>
   <build_depend>pr2_hardware_interface</build_depend>
   <build_depend>pr2_mechanism_model</build_depend>
   <build_depend>pr2_mechanism_diagnostics</build_depend>
@@ -42,6 +43,8 @@
   <run_depend>rospy</run_depend>
   <run_depend>rosparam</run_depend>
   <run_depend>pluginlib</run_depend>
+  <run_depend>tinyxml</run_depend>
+
 
   <export>
     <pr2_controller_interface plugin="${prefix}/test/controller_plugin.xml"/>

--- a/pr2_controller_manager/src/controller_manager.cpp
+++ b/pr2_controller_manager/src/controller_manager.cpp
@@ -831,4 +831,3 @@ bool ControllerManager::switchControllerSrv(
   ROS_DEBUG("switching service finished");
   return true;
 }
-

--- a/pr2_controller_manager/test/controller_test.launch
+++ b/pr2_controller_manager/test/controller_test.launch
@@ -20,6 +20,10 @@
   <rosparam file="$(find pr2_controller_manager)/test/controller_config_broken10.yaml" ns="controller18" command="load" />
   <rosparam file="$(find pr2_controller_manager)/test/controller_config_broken11.yaml" ns="controller19" command="load" />
 
+  <!-- fake robot -->
+  <node pkg="pr2_controller_manager" type="test_robot" name="test_robot" />
+  <include file="$(find pr2_description)/robots/upload_pr2.launch" />
+
   <!-- Spawn some controllers stopped/started -->
   <node pkg="pr2_controller_manager" type="spawner" args="controller1" name="spawn1"/>
   <node pkg="pr2_controller_manager" type="spawner" args="--stopped controller2" name="spawn2" />
@@ -32,10 +36,6 @@
 
   <!-- Diagnostics -->
   <node pkg="pr2_mechanism_diagnostics" type="pr2_mechanism_diagnostics" name="pr2_mechanism_diagnostics" />
-
-  <!-- fake robot -->
-  <node pkg="pr2_controller_manager" type="test_robot" name="test_robot" />
-  <include file="$(find pr2_description)/robots/upload_pr2.launch" />
 
   <!-- test -->
   <test test-name="test_controller_manager" pkg="pr2_controller_manager" type="test_controllers" time-limit="200" />

--- a/pr2_controller_manager/test/robot.cpp
+++ b/pr2_controller_manager/test/robot.cpp
@@ -65,7 +65,7 @@ int main(int argc, char** argv)
     ROS_ERROR("Could not parse the robot description");
     return -1;
   }
-  
+
   // Initialize controller manager from robot description
   if (!cm.initXml(robot_description_root)){
     ROS_ERROR("Could not initialize controller manager");
@@ -85,5 +85,3 @@ int main(int argc, char** argv)
 
   return 0;
 }
-
-

--- a/pr2_mechanism_diagnostics/CMakeLists.txt
+++ b/pr2_mechanism_diagnostics/CMakeLists.txt
@@ -5,17 +5,24 @@ project(pr2_mechanism_diagnostics)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS roscpp urdf rospy diagnostic_updater diagnostic_msgs pr2_mechanism_msgs pr2_mechanism_model angles std_srvs std_msgs rostest)
 
-find_package(PkgConfig)
-pkg_check_modules(PC_EIGEN REQUIRED eigen3)
-include_directories(include ${PC_EIGEN_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
-add_definitions(${PC_EIGEN_CFLAGS_OTHER})
+#find_package(PkgConfig)
+#pkg_check_modules(PC_EIGEN REQUIRED eigen3)
+#include_directories(include ${PC_EIGEN_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+#add_definitions(${PC_EIGEN_CFLAGS_OTHER})
+
+find_package(Eigen3 REQUIRED)
+
+include_directories(
+   include
+   ${catkin_INCLUDE_DIRS}
+   ${EIGEN_INCLUDE_DIRS})
 
 catkin_package()
 
 add_definitions(-O3)
 
-add_library(${PROJECT_NAME} 
-  src/controller_diagnostics.cpp 
+add_library(${PROJECT_NAME}
+  src/controller_diagnostics.cpp
   src/joint_diagnostics.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 

--- a/pr2_mechanism_model/CMakeLists.txt
+++ b/pr2_mechanism_model/CMakeLists.txt
@@ -5,13 +5,14 @@ project(pr2_mechanism_model)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS cmake_modules roscpp pr2_hardware_interface urdf kdl_parser pluginlib angles hardware_interface rostest rosunit)
 
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(urdfdom REQUIRED)
+find_package(TinyXML REQUIRED)
 include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS})
-include_directories(include ${catkin_INCLUDE_DIRS} ${urdfdom_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${urdfdom_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS})
 
 catkin_package(
-    DEPENDS tinyxml urdfdom
+    DEPENDS TinyXML urdfdom
     CATKIN_DEPENDS roscpp pr2_hardware_interface urdf kdl_parser pluginlib angles hardware_interface
     INCLUDE_DIRS include
     LIBRARIES pr2_mechanism_model
@@ -31,10 +32,10 @@ add_library( pr2_mechanism_model
   src/joint_calibration_simulator.cpp
 )
 pr2_enable_rpath(pr2_mechanism_model)
-target_link_libraries(pr2_mechanism_model ${catkin_LIBRARIES} )
+target_link_libraries(pr2_mechanism_model ${catkin_LIBRARIES} ${TinyXML_LIBRARIES})
 
 catkin_add_gtest(test_chain test/test_chain.cpp)
-target_link_libraries(test_chain pr2_mechanism_model ${catkin_LIBRARIES})
+target_link_libraries(test_chain pr2_mechanism_model ${catkin_LIBRARIES} ${TinyXML_LIBRARIES})
 
 catkin_add_gtest(test_wrist_transmission test/test_wrist_transmission.cpp)
 target_link_libraries(test_wrist_transmission pr2_mechanism_model ${catkin_LIBRARIES})

--- a/pr2_mechanism_model/include/pr2_mechanism_model/robot.h
+++ b/pr2_mechanism_model/include/pr2_mechanism_model/robot.h
@@ -126,8 +126,11 @@ private:
 class RobotState : public hardware_interface::HardwareInterface
 {
 public:
-  /// constructor
+  /// Constructor
   RobotState(Robot *model);
+
+  /// Default Constructor
+  RobotState();
 
   /// The robot model containing the transmissions, urdf robot model, and hardware interface
   Robot *model_;

--- a/pr2_mechanism_model/package.xml
+++ b/pr2_mechanism_model/package.xml
@@ -29,6 +29,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>tinyxml</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>pr2_hardware_interface</build_depend>
@@ -49,6 +50,7 @@
   <run_depend>pluginlib</run_depend>
   <run_depend>angles</run_depend>
   <run_depend>hardware_interface</run_depend>
+  <run_depend>tinyxml</run_depend>
 
   <export>
     <pr2_mechanism_model plugin="${prefix}/transmission_plugins.xml"/>

--- a/pr2_mechanism_model/src/robot.cpp
+++ b/pr2_mechanism_model/src/robot.cpp
@@ -47,7 +47,6 @@ Robot::Robot(HardwareInterface *hw)
   :hw_(hw)
 {}
 
-
 bool Robot::initXml(TiXmlElement *root)
 {
   // check if current time is valid
@@ -115,7 +114,7 @@ ros::Time Robot::getTime()
 }
 
 template <class T>
-int findIndexByName(const std::vector<boost::shared_ptr<T> >& v, 
+int findIndexByName(const std::vector<boost::shared_ptr<T> >& v,
       const std::string &name)
 {
   for (unsigned int i = 0; i < v.size(); ++i)
@@ -149,6 +148,7 @@ boost::shared_ptr<Transmission> Robot::getTransmission(const std::string &name) 
 RobotState::RobotState(Robot *model)
   : model_(model)
 {
+
   assert(model_);
 
   transmissions_in_.resize(model->transmissions_.size());
@@ -188,6 +188,11 @@ RobotState::RobotState(Robot *model)
     ROS_WARN("No transmissions were specified in the robot description.");
   if (js_size == 0)
     ROS_WARN("None of the joints in the robot desription matches up to a motor. The robot is uncontrollable.");
+}
+
+RobotState::RobotState()
+{
+  ROS_WARN("RobotState instantiated without model");
 }
 
 
@@ -275,5 +280,3 @@ void RobotState::propagateActuatorEffortToJointEffort()
                                                         transmissions_out_[i]);
   }
 }
-
-

--- a/pr2_mechanism_model/test/test_chain.cpp
+++ b/pr2_mechanism_model/test/test_chain.cpp
@@ -27,6 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <ros/package.h>
 #include <gtest/gtest.h>
 #include <vector>
 #include <boost/scoped_ptr.hpp>
@@ -55,7 +56,7 @@ protected:
 TEST_F(ShortChainTest, FKShouldMatchOnShortChainWhenStraight)
 {
   TiXmlDocument urdf_xml;
-  urdf_xml.LoadFile("pr2.urdf");
+  urdf_xml.LoadFile(ros::package::getPath("pr2_mechanism_model") + "/test/robot.xml");
   TiXmlElement *root = urdf_xml.FirstChildElement("robot");
   ASSERT_TRUE(root != NULL);
   pr2_hardware_interface::HardwareInterface hw;


### PR DESCRIPTION
I assumed that instead of _pr2.urdf_  this test should use the _robot.xml_ in the same directory.
To get the path of the file I added the usage of the _getPath_ function of the _package_ namespace.

According to the name this test was once meant to do check something different now it will at least correctly check, if a robot description can be parsed and used to initialize a robot model.

This change will keep the test from failing but maybe this test could be extended and renamed to clarify it's intention.

