### PR TITLE
Fix cmake warning

### DIFF
--- a/pr2_controller_manager/CMakeLists.txt
+++ b/pr2_controller_manager/CMakeLists.txt
@@ -5,14 +5,14 @@ project(pr2_controller_manager)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS cmake_modules pr2_hardware_interface pr2_mechanism_model pr2_mechanism_diagnostics pr2_description pr2_controller_interface pr2_mechanism_msgs diagnostic_msgs sensor_msgs realtime_tools roscpp pluginlib rostest)
 
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system thread)
 
 include_directories(
    include 
    ${Boost_INCLUDE_DIRS} 
    ${catkin_INCLUDE_DIRS} 
-   ${EIGEN_INCLUDE_DIRS})
+   ${EIGEN3_INCLUDE_DIRS})
 
 catkin_package(
     DEPENDS tinyxml

--- a/pr2_controller_manager/CMakeLists.txt
+++ b/pr2_controller_manager/CMakeLists.txt
@@ -6,6 +6,7 @@ project(pr2_controller_manager)
 find_package(catkin REQUIRED COMPONENTS cmake_modules pr2_hardware_interface pr2_mechanism_model pr2_mechanism_diagnostics pr2_description pr2_controller_interface pr2_mechanism_msgs diagnostic_msgs sensor_msgs realtime_tools roscpp pluginlib rostest)
 
 find_package(Eigen3 REQUIRED)
+find_package(TinyXML REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system thread)
 
 include_directories(
@@ -15,7 +16,7 @@ include_directories(
    ${EIGEN3_INCLUDE_DIRS})
 
 catkin_package(
-    DEPENDS tinyxml
+    DEPENDS TinyXML
     CATKIN_DEPENDS pr2_hardware_interface pr2_mechanism_model pr2_mechanism_diagnostics pr2_description pr2_controller_interface pr2_mechanism_msgs diagnostic_msgs sensor_msgs realtime_tools roscpp pluginlib
     INCLUDE_DIRS include
     LIBRARIES pr2_controller_manager
@@ -25,7 +26,7 @@ add_definitions(-O3)
 
 add_library(pr2_controller_manager src/controller_manager.cpp src/scheduler.cpp)
 
-target_link_libraries(pr2_controller_manager ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(pr2_controller_manager ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${TinyXML_LIBRARIES})
 
 add_library(controller_test test/controllers/test_controller.cpp)
 pr2_enable_rpath(controller_test)

--- a/pr2_mechanism_diagnostics/CMakeLists.txt
+++ b/pr2_mechanism_diagnostics/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(${PROJECT_NAME}
   src/controller_diagnostics.cpp 
   src/joint_diagnostics.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
-add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS} pr2_mechanism_msgs_gencpp)
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 
 add_executable(pr2_mechanism_diagnostics_node src/pr2_mechanism_diagnostics.cpp)
 target_link_libraries(pr2_mechanism_diagnostics_node ${PROJECT_NAME} ${catkin_LIBRARIES})


### PR DESCRIPTION
Fix cmake warnings

```
  Please use the FindEigen3.cmake Module provided with Eigen.  Change
  instances of find_package(Eigen) to find_package(Eigen3).  Check the
  FindEigen3.cmake Module for the resulting CMake variable names.

```
```
  catkin_package() DEPENDS on 'tinyxml' but neither 'tinyxml_INCLUDE_DIRS'
  nor 'tinyxml_LIBRARIES' is defined.
Call Stack (most recent call first):
  /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)
  CMakeLists.txt:17 (catkin_package)

```
```
  The dependency target "pr2_mechanism_msgs_gencpp" of target
  "pr2_mechanism_diagnostics" does not exist.
This warning is for project developers.  Use -Wno-dev to suppress it.

```