### PR TITLE
fix compile warning

### DIFF
--- a/pr2_mechanism_model/CMakeLists.txt
+++ b/pr2_mechanism_model/CMakeLists.txt
@@ -5,13 +5,14 @@ project(pr2_mechanism_model)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS cmake_modules roscpp pr2_hardware_interface urdf kdl_parser pluginlib angles hardware_interface rostest rosunit)
 
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(TinyXML REQUIRED)
 find_package(urdfdom REQUIRED)
-include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS})
+include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS})
 include_directories(include ${catkin_INCLUDE_DIRS} ${urdfdom_INCLUDE_DIRS})
 
 catkin_package(
-    DEPENDS tinyxml urdfdom
+    DEPENDS TinyXML urdfdom
     CATKIN_DEPENDS roscpp pr2_hardware_interface urdf kdl_parser pluginlib angles hardware_interface
     INCLUDE_DIRS include
     LIBRARIES pr2_mechanism_model


### PR DESCRIPTION
```
CMake Warning at /opt/ros/kinetic/share/cmake_modules/cmake/Modules/FindEigen.cmake:62 (message):
  The FindEigen.cmake Module in the cmake_modules package is deprecated.

  Please use the FindEigen3.cmake Module provided with Eigen.  Change
  instances of find_package(Eigen) to find_package(Eigen3).  Check the
  FindEigen3.cmake Module for the resulting CMake variable names.

Call Stack (most recent call first):
  CMakeLists.txt:8 (find_package)


CMake Warning at /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:166 (message):
  catkin_package() DEPENDS on 'tinyxml' but neither 'tinyxml_INCLUDE_DIRS'
  nor 'tinyxml_LIBRARIES' is defined.
Call Stack (most recent call first):
  /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)
  CMakeLists.txt:13 (catkin_package)
```