### PR TITLE
set hardware_interface >= 0.13.0

### DIFF
--- a/pr2_mechanism_model/package.xml
+++ b/pr2_mechanism_model/package.xml
@@ -37,7 +37,7 @@
   <build_depend>kdl_parser</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>angles</build_depend>
-  <build_depend>hardware_interface</build_depend>
+  <build_depend version_gte="0.13.0">hardware_interface</build_depend>
   <build_depend>rostest</build_depend>
   <build_depend>rosunit</build_depend>
 


### PR DESCRIPTION
https://github.com/ros-controls/ros_control/pull/285 (which is included in hardware_interface 0.13.0) allow us to use class `hardware_interface::HardwareResourceManager` API


see https://github.com/ros-controls/ros_control/pull/285 and https://github.com/PR2/pr2_mechanism/issues/330