### PR TITLE
Parse old & new transmission style

### DIFF
--- a/pr2_mechanism_model/src/robot.cpp
+++ b/pr2_mechanism_model/src/robot.cpp
@@ -71,7 +71,16 @@ bool Robot::initXml(TiXmlElement *root)
   for (xit = root->FirstChildElement("transmission"); xit;
        xit = xit->NextSiblingElement("transmission"))
   {
-    std::string type(xit->Attribute("type"));
+    // for the old and new transmission style
+    std::string type;
+    if(!xit->Attribute("type"))
+    {
+      if(!xit->FirstChildElement("type")) continue;
+      type = xit->FirstChildElement("type")->GetText();
+    }
+    else
+      type = xit->Attribute("type");
+    if(type.substr(0, 3) != "pr2") continue;
     boost::shared_ptr<Transmission> t;
     try {
       // Backwards compatibility for using non-namespaced controller types

--- a/pr2_mechanism_model/src/simple_transmission.cpp
+++ b/pr2_mechanism_model/src/simple_transmission.cpp
@@ -82,7 +82,11 @@ bool SimpleTransmission::initXml(TiXmlElement *elt, Robot *robot)
   a->command_.enable_ = true;
   actuator_names_.push_back(actuator_name);
 
-  mechanical_reduction_ = atof(elt->FirstChildElement("mechanicalReduction")->GetText());
+  // for the old and new transmission style
+  if(ael->FirstChildElement("mechanicalReduction"))
+    mechanical_reduction_ = atof(ael->FirstChildElement("mechanicalReduction")->GetText());
+  else
+    mechanical_reduction_ = atof(elt->FirstChildElement("mechanicalReduction")->GetText());
 
   // Get screw joint informations
   for (TiXmlElement *j = elt->FirstChildElement("simulated_actuated_joint"); j; j = j->NextSiblingElement("simulated_actuated_joint"))


### PR DESCRIPTION
The transmission style changed in ros_control, to make them compatible
we adjusted them in the pr2_description

This came up when we integrated the shadow-hand- and the PR2-model and has been lying around for six years (wow...)