### PR TITLE
set catkin_add_gtest within CATKIN_ENABLE_TESTING

### DIFF
--- a/pr2_controller_manager/CMakeLists.txt
+++ b/pr2_controller_manager/CMakeLists.txt
@@ -34,15 +34,17 @@ add_dependencies(controller_test ${catkin_EXPORTED_TARGETS})
 pr2_enable_rpath(controller_test)
 target_link_libraries(controller_test ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
-add_executable(test_controllers test/test.cpp)
-add_dependencies(test_controllers ${catkin_EXPORTED_TARGETS})
-add_executable(test_robot test/robot.cpp)
+if(CATKIN_ENABLE_TESTING)
+  add_executable(test_controllers test/test.cpp)
+  add_dependencies(test_controllers ${catkin_EXPORTED_TARGETS})
+  add_executable(test_robot test/robot.cpp)
 
-target_link_libraries(test_robot ${Boost_LIBRARIES} ${PROJECT_NAME} ${catkin_LIBRARIES})
+  target_link_libraries(test_robot ${Boost_LIBRARIES} ${PROJECT_NAME} ${catkin_LIBRARIES})
 
-target_link_libraries(test_controllers ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
+  target_link_libraries(test_controllers ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
 
-add_rostest(test/controller_test.launch)
+  add_rostest(test/controller_test.launch)
+endif()
 
 file(GLOB PYTHON_SCRIPTS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" 
    "${CMAKE_CURRENT_SOURCE_DIR}/scripts/*")

--- a/pr2_mechanism_diagnostics/CMakeLists.txt
+++ b/pr2_mechanism_diagnostics/CMakeLists.txt
@@ -25,10 +25,12 @@ add_executable(pr2_mechanism_diagnostics_node src/pr2_mechanism_diagnostics.cpp)
 target_link_libraries(pr2_mechanism_diagnostics_node ${PROJECT_NAME} ${catkin_LIBRARIES})
 set_target_properties(pr2_mechanism_diagnostics_node PROPERTIES OUTPUT_NAME pr2_mechanism_diagnostics)
 
-add_rostest(test/launch/mech_diag_test_main.launch)
-add_rostest(test/launch/overrun_test.launch)
-add_rostest(test/launch/uncal_test.launch)
-add_rostest(test/launch/nan_test.launch)
+if(CATKIN_ENABLE_TESTING)
+  add_rostest(test/launch/mech_diag_test_main.launch)
+  add_rostest(test/launch/overrun_test.launch)
+  add_rostest(test/launch/uncal_test.launch)
+  add_rostest(test/launch/nan_test.launch)
+endif()
 
 install(TARGETS pr2_mechanism_diagnostics_node
    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/pr2_mechanism_model/CMakeLists.txt
+++ b/pr2_mechanism_model/CMakeLists.txt
@@ -41,23 +41,25 @@ endif()
 pr2_enable_rpath(pr2_mechanism_model)
 target_link_libraries(pr2_mechanism_model ${catkin_LIBRARIES} )
 
-catkin_add_gtest(test_chain test/test_chain.cpp)
-target_link_libraries(test_chain pr2_mechanism_model ${catkin_LIBRARIES})
+if(CATKIN_ENABLE_TESTING)
+  catkin_add_gtest(test_chain test/test_chain.cpp)
+  target_link_libraries(test_chain pr2_mechanism_model ${catkin_LIBRARIES})
 
-catkin_add_gtest(test_wrist_transmission test/test_wrist_transmission.cpp)
-target_link_libraries(test_wrist_transmission pr2_mechanism_model ${catkin_LIBRARIES})
+  catkin_add_gtest(test_wrist_transmission test/test_wrist_transmission.cpp)
+  target_link_libraries(test_wrist_transmission pr2_mechanism_model ${catkin_LIBRARIES})
 
-# test joint calibration simulator for writing actuator state optical flags
-#  in propagatePositionBackwards() call
-add_executable(test_joint_calibration_simulator 
-   test/test_joint_calibration_simulator.cpp
-   src/joint_calibration_simulator.cpp)
-target_link_libraries(test_joint_calibration_simulator pr2_mechanism_model ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
-add_dependencies(test_joint_calibration_simulator gtest gtest_main)
-add_dependencies(tests test_joint_calibration_simulator)
-set_target_properties(test_joint_calibration_simulator PROPERTIES EXCLUDE_FROM_ALL TRUE)
+  # test joint calibration simulator for writing actuator state optical flags
+  #  in propagatePositionBackwards() call
+  add_executable(test_joint_calibration_simulator
+    test/test_joint_calibration_simulator.cpp
+    src/joint_calibration_simulator.cpp)
+  target_link_libraries(test_joint_calibration_simulator pr2_mechanism_model ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
+  add_dependencies(test_joint_calibration_simulator gtest gtest_main)
+  add_dependencies(tests test_joint_calibration_simulator)
+  set_target_properties(test_joint_calibration_simulator PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
-add_rostest(test/test_joint_calibration_simulator.launch)
+  add_rostest(test/test_joint_calibration_simulator.launch)
+endif()
 
 install(DIRECTORY include/${PROJECT_NAME}/
    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})


### PR DESCRIPTION
fix
    ``` Install RPATH for pr2_mechanism_model is
    /opt/jsk/System/ros1_inst/lib:/opt/jsk/System/ros1_inst/share/eusli
    sp/jskeus/eus//Linux64/lib:/opt/jsk/System/ros1_inst/lib:/opt/ros/melodic/lib:/opt/jsk/System/ros1_dependenc
    ies/lib CMake Error at
    /opt/ros/melodic/share/catkin/cmake/test/tests.cmake:18 (message):
     () is not available when tests are not enabled.  The CMake code should
    only
     use it inside a conditional block which checks that testing is enabled:

      if(CATKIN_ENABLE_TESTING)

        (...)

      endif()

    Call Stack (most recent call first):
     CMakeLists.txt:44 (catkin_add_gtest) e
    ```