### PR TITLE
Import setup from setuptools instead of distutils.core

### DIFF
--- a/pr2_controller_manager/package.xml
+++ b/pr2_controller_manager/package.xml
@@ -14,6 +14,8 @@
   <author>Wim Meeussen</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
   <build_depend>pr2_hardware_interface</build_depend>

--- a/pr2_controller_manager/package.xml
+++ b/pr2_controller_manager/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>pr2_controller_manager</name>
   <version>1.8.21</version>
   <description>The controller manager (CM) package provides the infrastructure to run controllers in a hard realtime loop.</description>
@@ -29,20 +29,20 @@
   <build_depend>pluginlib</build_depend>
   <build_depend>rostest</build_depend>
 
-  <run_depend>pr2_hardware_interface</run_depend>
-  <run_depend>pr2_mechanism_model</run_depend>
-  <run_depend>pr2_mechanism_diagnostics</run_depend>
-  <run_depend>pr2_description</run_depend>
-  <run_depend>pr2_controller_interface</run_depend>
-  <run_depend>pr2_mechanism_msgs</run_depend>
-  <run_depend>diagnostic_msgs</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>realtime_tools</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>rosparam</run_depend>
-  <run_depend>pluginlib</run_depend>
+  <exec_depend>pr2_hardware_interface</exec_depend>
+  <exec_depend>pr2_mechanism_model</exec_depend>
+  <exec_depend>pr2_mechanism_diagnostics</exec_depend>
+  <exec_depend>pr2_description</exec_depend>
+  <exec_depend>pr2_controller_interface</exec_depend>
+  <exec_depend>pr2_mechanism_msgs</exec_depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>realtime_tools</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>rosparam</exec_depend>
+  <exec_depend>pluginlib</exec_depend>
 
   <test_depend>roslaunch</test_depend>
 

--- a/pr2_controller_manager/setup.py
+++ b/pr2_controller_manager/setup.py
@@ -1,6 +1,6 @@
 ## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml


### PR DESCRIPTION
Recently users of newer distributions who build Noetic from source noticed issues when importing setup from distutils.core.
This problem was discussed on [Discourse](https://discourse.ros.org/t/ros-1-and-python-3-10s-deprecation-of-distutils-core/29834), and we hope that we can make the needed updates to Noetic to allow for future builds from source of Noetic.
As a first step, this PR introduces changes from the [Noetic Migration Guide](https://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils) that addresses the change to the setuptools module instead of distutils.core and the corresponding buildtool_depend tags for python 2&3.